### PR TITLE
conditionally render loader container

### DIFF
--- a/src/app/views/Dashboard/index.tsx
+++ b/src/app/views/Dashboard/index.tsx
@@ -38,10 +38,16 @@ export default function Home() {
   }, [publicKey]);
 
   return (
-    <LoaderContainer loading={isLoading} error={!!err} errorMessage={err}>
-      <SectionOne profile={profile} />
-      <SectionTwo activeTab={activeTab} setActiveTab={setActiveTab} />
-      {activeTab === "Details" && <SectionThree />}
-    </LoaderContainer>
+    <>
+      {isLoading ? (
+        <LoaderContainer loading={isLoading} error={!!err} errorMessage={err} />
+      ) : (
+        <>
+          <SectionOne profile={profile} />
+          <SectionTwo activeTab={activeTab} setActiveTab={setActiveTab} />
+          {activeTab === "Details" && <SectionThree />}
+        </>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
This is a super simple PR. All it does it moves the Dashboard sections outside of the LoaderContainer and into a Fragment (<>) and chooses which to render based on the isLoading state variable.

Motivation: Having the Sections nested inside the LoaderContainer as children altered their styling and shifted the page, making it not look exactly like the figma drawing. Conditionally choosing between the LoaderContainer or the normal page (ie. the sections) solves this problem.

If isLoading == true:
  Only LoaderContainer is rendered

Else:
  Renders Sections One, Two, and 3 as before.

